### PR TITLE
Store address use case

### DIFF
--- a/src/use_cases/store_address/StoreAddressUseCase.php
+++ b/src/use_cases/store_address/StoreAddressUseCase.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\UseCases\store_address;
+
+use App\UseCases\store_address\StoreAddressUseCaseInputDTO;
+use App\Domain\address\entity\AddressEntity;
+use App\Domain\address\value_object\ZipCodeValueObject;
+use App\Domain\address\value_object\state\BrazilianStateValueObject;
+use App\Domain\address\repository\AddressRepositoryInterface;
+
+class StoreAddressUseCase
+{
+    private AddressRepositoryInterface $addressRepository;
+
+    public function __construct(AddressRepositoryInterface $addressRepository)
+    {
+        $this->addressRepository = $addressRepository;
+    }
+
+    public function execute(StoreAddressUseCaseInputDTO $addressInput): void
+    {
+        $zipCodeInstance = new ZipCodeValueObject($addressInput->zipCode);
+        $stateUFInstance = new BrazilianStateValueObject($addressInput->stateUF);
+
+        $addressEntity = new AddressEntity(
+            zipCode: $zipCodeInstance,
+            stateUF: $stateUFInstance,
+            street: $addressInput->street,
+            city: $addressInput->city,
+            number: $addressInput->number,
+            complement: $addressInput->complement,
+            district: $addressInput->district
+        );
+
+        $this->addressRepository->save($addressEntity);
+    }
+}

--- a/src/use_cases/store_address/StoreAddressUseCaseInputDTO.php
+++ b/src/use_cases/store_address/StoreAddressUseCaseInputDTO.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\UseCases\store_address;
+
+class StoreAddressUseCaseInputDTO
+{
+    public string $zipCode;
+    public string $stateUF;
+    public string $street;
+    public string $city;
+    public string $number;
+    public string $complement;
+    public string $district;
+
+    public function __construct(
+        string $zipCode,
+        string $stateUF,
+        string $street,
+        string $city,
+        string $number = null,
+        string $complement = null,
+        string $district = null,
+    ) {
+        $this->zipCode = $zipCode;
+        $this->stateUF = $stateUF;
+        $this->street = $street;
+        $this->city = $city;
+        $this->number = $number;
+        $this->complement = $complement;
+        $this->district = $district;
+    }
+}

--- a/tests/unit/use_cases/StoreAddressUseCaseTest.php
+++ b/tests/unit/use_cases/StoreAddressUseCaseTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+use App\UseCases\store_address\StoreAddressUseCaseInputDTO;
+use App\UseCases\store_address\StoreAddressUseCase;
+use App\Domain\address\repository\AddressRepositoryInterface;
+
+class StoreAddressUseCaseTest extends TestCase
+{
+    public function testItShouldSuccessfullyStoreAddress()
+    {
+        $addressInputDTO = new StoreAddressUseCaseInputDTO(
+            zipCode: '12345-678',
+            stateUF: 'SC',
+            street: 'Rua 1',
+            city: 'Santa Catarina',
+            number: '0',
+            complement: 'Apartamento 101',
+            district: 'Centro'
+        );
+
+        $addressRepositoryMock = $this->createMock(AddressRepositoryInterface::class);
+        $addressRepositoryMock->expects($this->once())
+            ->method('save');
+
+        $storeAddressUseCase = new StoreAddressUseCase($addressRepositoryMock);
+        $storeAddressUseCase->execute($addressInputDTO);
+    }
+}


### PR DESCRIPTION

Este Pull Request introduz a implementação completa do `StoreAddressUseCase`, incluindo DTOs e testes unitários. Esta nova funcionalidade permite armazenar endereços de forma eficiente e confiável no sistema.

## Mudanças Principais
- **Implementação do `StoreAddressUseCase`:** O caso de uso foi desenvolvido para permitir a adição de novos endereços no sistema.
- **DTOs para `StoreAddressUseCase`:** Foram criados DTOs para facilitar a transferência de dados necessários para o armazenamento de endereços.
- **Testes Unitários:** Uma série de testes unitários foram adicionados para garantir a correta funcionalidade e validações dentro do caso de uso.
